### PR TITLE
Doc: bump cmake >= 3.18

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,5 @@
-### Getting Started & Building:
+# Getting Started & Building
+
 1. Prerequisites:
    * CMake version 3.18.0+
      * Ubuntu systems may have a problem getting the latest cmake version
@@ -8,12 +9,15 @@
      * python packages: sphinx, breathe, divio-docs-theme
      * doxygen
 2. Checkout the repository:
+
     ```sh
     # --recursive flag is needed to pull in the submodule
     git clone https://github.com/codereport/jsource.git --recursive
     ```
+
 3. Build jconsole:
    * Run cmake:
+
     ```sh
     cd jsource
     mkdir build
@@ -21,27 +25,38 @@
     # If you want documentation built, modify your cmake command to:
     cmake -G "Ninja Multi-Config" -B build -DDOCS:STRING=YES
     ```
+
    * To build debug:
+
     ```sh
     ninja -C build
     ```
+
    * To build release:
+
     ```sh
     ninja -C build -f build-Release.ninja
     ```
+
 4. Run jconsole:
    * To run the debug build:
+
     ```sh
     ./build/jsrc/Debug/jconsole
     ```
+
    * To run the release build:
+
     ```sh
     ./build/jsrc/Release/jconsole
     ```
+
 5. Run tests:
+
     ```sh
     ninja -C build test
     ```
+
    * Filter tests:
 
     ```sh
@@ -52,6 +67,7 @@
    ```
 
 Extra: Get JHS Web IDE
-```
+
+```sh
 ./build/jsrc/Debug/jconsole ./jlibrary/addons/ide/jhs/config/jhs.cfg
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 ### Getting Started & Building:
 1. Prerequisites:
-   * CMake version 3.17.0+ -> Ubuntu systems seem to have a problem getting the latest version, please build from sources or use another package such as snap.
-     * [Ubuntu CMake update instructions](https://apt.kitware.com/)
+   * CMake version 3.18.0+
+     * Ubuntu systems may have a problem getting the latest cmake version
+       * [Ubuntu CMake update instructions](https://apt.kitware.com/)
    * Ninja
    * Additional prerequisites for building the documentation:
      * python packages: sphinx, breathe, divio-docs-theme


### PR DESCRIPTION
AAL cmake was bumped to 3.18.0
This PR updates the CONTRIBUTING doc to match
and fixes md  errors flagged by vscode linter